### PR TITLE
fix: remove false positive from the ruleset

### DIFF
--- a/spectral/ruleset.yaml
+++ b/spectral/ruleset.yaml
@@ -56,7 +56,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "\/api\/([a-z_]*){1,}(\/v[0-9]*(alpha|beta)?)(\/{?[a-z_]*}?){0,}$"
+        match: "\/api\/v.*\/.*$"
   rhoas-response-media-type:
     given: "$.paths.*.*.responses.*.content"
     description: application/json is the only acceptable content type


### PR DESCRIPTION
Many complain that our ruleset contain invalid values around api path. This change makes validator more leanient  /api/vwhatever/object would pass it, but we should be good enough to not print some of the messages for clearly valid cases.