### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
       - run: yarn install
         working-directory: ./spectral
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        # v4
+        uses: rlespinasse/github-slug-action@a362e5fb42057a3a23a62218b050838f1bacca5d
       - name: Validate Tag
         working-directory: ./spectral
         run: yarn semver $GITHUB_REF_SLUG


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.